### PR TITLE
Cleanup of the code

### DIFF
--- a/bench/README.md
+++ b/bench/README.md
@@ -1,0 +1,9 @@
+# Benchmarks
+
+This folder has all the source code/projects used to benchmark the allocator. The next are the available benchmarks:
+
+* **randomalloc_synthetic**: given the average distance between a malloc and it's respective free (`-d` flag), it constructs an array of operations and goes executing those operations and timing what cost each allocation/deallocation has.
+
+* **randomsize_fifo_synthetic**: given the parameters for the beta distribution (`-a` and `-b` flags), it chooses the allocation size. Used to benchmark performance benefits on favorable sizes and performance loss when slabs are not used.
+
+* **cfrac**: cfrac is a general purpose factorization algorithm that has many small temporal allocations (theoretically benefitial to the slab allocator).

--- a/src/heuristic.c
+++ b/src/heuristic.c
@@ -9,7 +9,7 @@ int heuristic_decision_grow_count(struct heuristic_params params, struct heurist
     return params.default_grow_rate;
 }
 
-bool heuristic_decision_does_unmap(struct heuristic_params params, struct heuristic_data data) {
+bool heuristic_decision_does_free_slab(struct heuristic_params params, struct heuristic_data data) {
     size_t empty_slabs = data.grow_count - data.shrink_count;
     return empty_slabs <= params.minimum_empty_slabs;
 }

--- a/src/heuristic.h
+++ b/src/heuristic.h
@@ -20,8 +20,14 @@ struct heuristic_data {
     size_t shrink_count;
 };
 
+/*
+ * Returns how much the slab pool should grow given the parameters and slab pool statistics.
+ */
 int heuristic_decision_grow_count(struct heuristic_params params, struct heuristic_data data);
 
+/*
+ * Returns whether a slab should be removed or not based on the given parameters and pool statistics
+ */
 bool heuristic_decision_does_unmap(struct heuristic_params params, struct heuristic_data data);
 
 #endif // SLAB_HEURISTIC_H

--- a/src/heuristic.h
+++ b/src/heuristic.h
@@ -28,6 +28,6 @@ int heuristic_decision_grow_count(struct heuristic_params params, struct heurist
 /*
  * Returns whether a slab should be removed or not based on the given parameters and pool statistics
  */
-bool heuristic_decision_does_unmap(struct heuristic_params params, struct heuristic_data data);
+bool heuristic_decision_does_free_slab(struct heuristic_params params, struct heuristic_data data);
 
 #endif // SLAB_HEURISTIC_H

--- a/src/slab_pool.c
+++ b/src/slab_pool.c
@@ -8,12 +8,6 @@
 #include "internal_assert.h"
 #include "utils.h"
 
-#ifdef POOL_CONFIG_DEBUG
-    #define debug(...) fprintf(stderr, __VA_ARGS__); fflush(stderr)
-#else
-    #define debug(...)
-#endif
-
 #define POOL_START_SIZE  10 
 #define POOL_GROW_RATE   10 
 #define POOL_MAX_GROW_RATE   5 
@@ -114,12 +108,6 @@ struct slab_pool slab_pool_create(size_t allocation_size) {
     result.data.deallocation_count = 0;
     result.data.grow_count = POOL_START_SIZE;
     result.data.shrink_count = 0;
-
-#ifdef POOL_CONFIG_DEBUG
-    debug("POOL: created pool of size %li\n", result.allocation_size);
-    int size = get_list_size(result.list_start);
-    debug("\t* Size of the list at the start is %i\n", size);
-#endif // POOL_CONFIG_DEBUG
 
     return result;
 }

--- a/src/slab_pool.c
+++ b/src/slab_pool.c
@@ -192,7 +192,7 @@ void slab_pool_deallocate(struct slab_pool* pool, void* ptr) {
     }
                                                                                             
     // Ask hour super good heuristic if we need to nuke the slab from the list.
-    bool heuristic_decision = heuristic_decision_does_unmap(pool->params, pool->data);
+    bool heuristic_decision = heuristic_decision_does_free_slab(pool->params, pool->data);
     bool is_empty = slab->ref_count == 0;
     bool is_lonely = slab->next == NULL && slab->prev == NULL;
     if(is_empty && !is_lonely && heuristic_decision) {


### PR DESCRIPTION
The code has been cleaned up by removing the `debug` macro used in the early days and commenting some undocumented functions.